### PR TITLE
Move Unity API call from Constructor to Awake.

### DIFF
--- a/Source/Core.cs
+++ b/Source/Core.cs
@@ -15,7 +15,7 @@ using System.Diagnostics;
 
 public class HyperEditModule : MonoBehaviour
 {
-    public HyperEditModule()
+    public void Awake() // Called after scene (designated w/ KSPAddon) loads, but before Start().  Init data here.
     {
         HyperEdit.Immortal.AddImmortal<HyperEdit.HyperEditBehaviour>();
     }


### PR DESCRIPTION
This is not allowed in future versions of Unity and causes problems in Unity Develop Player and Editor.