### PR TITLE
Change settings directory

### DIFF
--- a/Source/Core.cs
+++ b/Source/Core.cs
@@ -283,12 +283,37 @@ namespace HyperEdit
 
     public static class IoExt
     {
-        private static readonly string RootDir = System.IO.Path.ChangeExtension(typeof(IoExt).Assembly.Location, null);
+        private static readonly string RootDir = System.IO.Path.Combine(KSPUtil.ApplicationRootPath, "PluginData/HyperEdit");
 
         static IoExt()
         {
             if (!System.IO.Directory.Exists(RootDir))
                 System.IO.Directory.CreateDirectory(RootDir);
+            
+            // Code to move settings from old location to new
+            // This can probably be removed in a couple of versions
+            try
+            {
+                string oldDir = System.IO.Path.ChangeExtension(typeof(IoExt).Assembly.Location, null);
+                if (System.IO.Directory.Exists(oldDir))
+                {
+                    foreach (string filePath in System.IO.Directory.GetFiles(oldDir, "*.cfg"))
+                    {
+                        string fileName = System.IO.Path.GetFileName(filePath);
+                        string newFilePath = System.IO.Path.Combine(RootDir, fileName);
+
+                        if (System.IO.File.Exists(newFilePath))
+                            System.IO.File.Delete(filePath);
+                        else
+                            System.IO.File.Move(filePath, newFilePath);
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                UnityEngine.Debug.LogException(e);
+            }
+
             Extensions.Log("Using \"" + RootDir + "\" as root config directory");
         }
 


### PR DESCRIPTION
Was `<ksp_root>/GameData/KerbalTek/HyperEdit/`, now
`<ksp_root>/PluginData/HyperEdit/`

There is also code to move files from the old location to the new
location so that the user's settings are not wiped

This prevents (1) KSP from loading these files into the game database
and (2) ModuleManager from considering them for its cache

There's no technical reason they couldn't e.g. be stored at e.g. `<ksp_root>/GameData/KerbalTek/PluginData/HyperEdit/` (this would accomplish the same thing), but moving settings files out of `GameData` prevents issues with e.g. CKAN removing a mod but leaving the directory because there are unrecognized files in it, making ModuleManager think that the mod is still installed