### PR TITLE
fix build and add library path for mac

### DIFF
--- a/HyperEdit.csproj
+++ b/HyperEdit.csproj
@@ -20,6 +20,11 @@
 -->
     <KspInstallDir Condition=" '$(KspInstallDir)' == '' ">..\..\..\Games\Kerbal Space Program\KSP_win64</KspInstallDir>
     <KspOutputPath>$(KspInstallDir)\GameData\Kerbaltek</KspOutputPath>
+<!-- // This is for Ezriilc's IDE, please leave this comment here, but change the next line (28) to your own KSP library directory.
+      <KspLibPath>$(KspInstallDir)\KSP_x64_Data\Managed</KspLibPath>
+      On a Mac this would be:
+      <KspLibPath>$(KspInstallDir)/KSP.app/Contents/Resources/Data/Managed</KspLibPath>
+-->
     <KspLibPath>$(KspInstallDir)\KSP_x64_Data\Managed</KspLibPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -45,6 +50,18 @@
     <Reference Include="System" />
     <Reference Include="UnityEngine">
       <HintPath>$(KspLibPath)\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.AnimationModule">
+      <HintPath>$(KspLibPath)\UnityEngine.AnimationModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(KspLibPath)\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>$(KspLibPath)\UnityEngine.IMGUIModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.PhysicsModule">
+      <HintPath>$(KspLibPath)\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>$(KspLibPath)\UnityEngine.UI.dll</HintPath>


### PR DESCRIPTION
In #52 I mentioned being unable to build the addon on my mac. There were two reasons for this:

1. There appear to have been some changes to how the game ships the UnityEngine DLLs, so a few more assembly references are required now. Hopefully this was made across the board and isn't a Mac-specific issue.
1. `KspLibPath` is in a different location on a Mac. I added a comment in the `Hyperedit.csproj` for what `KspLibPath` should be on a Mac (as well as @Ezriilc's original path).

Note that this doesn't fix the bug I introduced in #52 yet. I'll push another update to that PR to fix it.