### PR TITLE
Add planet editors for atmosphereTemperatureCurve, atmospherePressureCurve, et cetera

### DIFF
--- a/Source/Model/PlanetEditor.cs
+++ b/Source/Model/PlanetEditor.cs
@@ -12,19 +12,30 @@ namespace HyperEdit.Model
         {
             // Included fields for copy-paste:
             /*
-                double GeeASL
-                bool   ocean
-                bool   atmosphere
-                bool   atmosphereContainsOxygen
-                double atmosphereDepth
-                double atmosphereTemperatureSeaLevel
-                double atmospherePressureSeaLevel
-                double atmosphereMolarMass
-                double atmosphereAdiabaticIndex
-                bool   rotates
-                double rotationPeriod
-                double initialRotation
-                bool   tidallyLocked
+                double     GeeASL
+                bool       ocean
+                bool       atmosphere
+                bool       atmosphereContainsOxygen
+                double     atmosphereDepth
+                double     atmosphereTemperatureSeaLevel
+                double     atmosphereTemperatureLapseRate
+                double     atmospherePressureSeaLevel
+                double     atmDensityASL
+                double     atmosphereGasMassLapseRate
+                double     atmosphereMolarMass
+                double     atmosphereAdiabaticIndex
+                double     radiusAtmoFactor
+                bool       atmosphereUsePressureCurve
+                bool       atmospherePressureCurveIsNormalized
+                FloatCurve atmospherePressureCurve
+                bool       atmosphereUseTemperatureCurve
+                bool       atmosphereTemperatureCurveIsNormalized
+                FloatCurve atmosphereTemperatureCurve
+                FloatCurve atmosphereTemperatureSunMultCurve
+                bool       rotates
+                double     rotationPeriod
+                double     initialRotation
+                bool       tidallyLocked
             */
 
             public double GeeASL { get; set; }
@@ -33,9 +44,20 @@ namespace HyperEdit.Model
             public bool atmosphereContainsOxygen { get; set; }
             public double atmosphereDepth { get; set; }
             public double atmosphereTemperatureSeaLevel { get; set; }
+            public double atmosphereTemperatureLapseRate { get; set; }
             public double atmospherePressureSeaLevel { get; set; }
+            public double atmDensityASL { get; set; }
+            public double atmosphereGasMassLapseRate { get; set; }
             public double atmosphereMolarMass { get; set; }
             public double atmosphereAdiabaticIndex { get; set; }
+            public double radiusAtmoFactor { get; set; }
+            public bool atmosphereUsePressureCurve { get; set; }
+            public bool atmospherePressureCurveIsNormalized { get; set; }
+            public FloatCurve atmospherePressureCurve { get; set; }
+            public bool atmosphereUseTemperatureCurve { get; set; }
+            public bool atmosphereTemperatureCurveIsNormalized { get; set; }
+            public FloatCurve atmosphereTemperatureCurve { get; set; }
+            public FloatCurve atmosphereTemperatureSunMultCurve { get; set; }
             public bool rotates { get; set; }
             public double rotationPeriod { get; set; }
             public double initialRotation { get; set; }
@@ -49,9 +71,20 @@ namespace HyperEdit.Model
                 bool atmosphereContainsOxygen,
                 double atmosphereDepth,
                 double atmosphereTemperatureSeaLevel,
+                double atmosphereTemperatureLapseRate,
                 double atmospherePressureSeaLevel,
+                double atmDensityASL,
+                double atmosphereGasMassLapseRate,
                 double atmosphereMolarMass,
                 double atmosphereAdiabaticIndex,
+                double radiusAtmoFactor,
+                bool atmosphereUsePressureCurve,
+                bool atmospherePressureCurveIsNormalized,
+                FloatCurve atmospherePressureCurve,
+                bool atmosphereUseTemperatureCurve,
+                bool atmosphereTemperatureCurveIsNormalized,
+                FloatCurve atmosphereTemperatureCurve,
+                FloatCurve atmosphereTemperatureSunMultCurve,
                 bool rotates,
                 double rotationPeriod,
                 double initialRotation,
@@ -64,9 +97,20 @@ namespace HyperEdit.Model
                 this.atmosphereContainsOxygen = atmosphereContainsOxygen;
                 this.atmosphereDepth = atmosphereDepth;
                 this.atmosphereTemperatureSeaLevel = atmosphereTemperatureSeaLevel;
+                this.atmosphereTemperatureLapseRate = atmosphereTemperatureLapseRate;
                 this.atmospherePressureSeaLevel = atmospherePressureSeaLevel;
+                this.atmDensityASL = atmDensityASL;
+                this.atmosphereGasMassLapseRate = atmosphereGasMassLapseRate;
                 this.atmosphereMolarMass = atmosphereMolarMass;
                 this.atmosphereAdiabaticIndex = atmosphereAdiabaticIndex;
+                this.radiusAtmoFactor = radiusAtmoFactor;
+                this.atmosphereUsePressureCurve = atmosphereUsePressureCurve;
+                this.atmospherePressureCurveIsNormalized = atmospherePressureCurveIsNormalized;
+                this.atmospherePressureCurve = atmospherePressureCurve;
+                this.atmosphereUseTemperatureCurve = atmosphereUseTemperatureCurve;
+                this.atmosphereTemperatureCurveIsNormalized = atmosphereTemperatureCurveIsNormalized;
+                this.atmosphereTemperatureCurve = atmosphereTemperatureCurve;
+                this.atmosphereTemperatureSunMultCurve = atmosphereTemperatureSunMultCurve;
                 this.rotates = rotates;
                 this.rotationPeriod = rotationPeriod;
                 this.initialRotation = initialRotation;
@@ -83,9 +127,20 @@ namespace HyperEdit.Model
                 atmosphereContainsOxygen = body.atmosphereContainsOxygen;
                 atmosphereDepth = body.atmosphereDepth;
                 atmosphereTemperatureSeaLevel = body.atmosphereTemperatureSeaLevel;
+                atmosphereTemperatureLapseRate = body.atmosphereTemperatureLapseRate;
                 atmospherePressureSeaLevel = body.atmospherePressureSeaLevel;
+                atmDensityASL = body.atmDensityASL;
+                atmosphereGasMassLapseRate = body.atmosphereGasMassLapseRate;
                 atmosphereMolarMass = body.atmosphereMolarMass;
                 atmosphereAdiabaticIndex = body.atmosphereAdiabaticIndex;
+                radiusAtmoFactor = body.radiusAtmoFactor;
+                atmosphereUsePressureCurve = body.atmosphereUsePressureCurve;
+                atmospherePressureCurveIsNormalized = body.atmospherePressureCurveIsNormalized;
+                atmospherePressureCurve = body.atmospherePressureCurve;
+                atmosphereUseTemperatureCurve = body.atmosphereUseTemperatureCurve;
+                atmosphereTemperatureCurveIsNormalized = body.atmosphereTemperatureCurveIsNormalized;
+                atmosphereTemperatureCurve = body.atmosphereTemperatureCurve;
+                atmosphereTemperatureSunMultCurve = body.atmosphereTemperatureSunMultCurve;
                 rotates = body.rotates;
                 rotationPeriod = body.rotationPeriod;
                 initialRotation = body.initialRotation;
@@ -106,9 +161,20 @@ namespace HyperEdit.Model
                 body.atmosphereContainsOxygen = atmosphereContainsOxygen;
                 body.atmosphereDepth = atmosphereDepth;
                 body.atmosphereTemperatureSeaLevel = atmosphereTemperatureSeaLevel;
+                body.atmosphereTemperatureLapseRate = atmosphereTemperatureLapseRate;
                 body.atmospherePressureSeaLevel = atmospherePressureSeaLevel;
+                body.atmDensityASL = atmDensityASL;
+                body.atmosphereGasMassLapseRate = atmosphereGasMassLapseRate;
                 body.atmosphereMolarMass = atmosphereMolarMass;
                 body.atmosphereAdiabaticIndex = atmosphereAdiabaticIndex;
+                body.radiusAtmoFactor = radiusAtmoFactor;
+                body.atmosphereUsePressureCurve = atmosphereUsePressureCurve;
+                body.atmospherePressureCurveIsNormalized = atmospherePressureCurveIsNormalized;
+                body.atmospherePressureCurve = atmospherePressureCurve;
+                body.atmosphereUseTemperatureCurve = atmosphereUseTemperatureCurve;
+                body.atmosphereTemperatureCurveIsNormalized = atmosphereTemperatureCurveIsNormalized;
+                body.atmosphereTemperatureCurve = atmosphereTemperatureCurve;
+                body.atmosphereTemperatureSunMultCurve = atmosphereTemperatureSunMultCurve;
                 body.rotates = rotates;
                 body.rotationPeriod = rotationPeriod;
                 body.initialRotation = initialRotation;
@@ -132,9 +198,32 @@ namespace HyperEdit.Model
                 node.AddValue("atmosphereContainsOxygen", body.atmosphereContainsOxygen);
                 node.AddValue("atmosphereDepth", body.atmosphereDepth);
                 node.AddValue("atmosphereTemperatureSeaLevel", body.atmosphereTemperatureSeaLevel);
+                node.AddValue("atmosphereTemperatureLapseRate", body.atmosphereTemperatureLapseRate);
                 node.AddValue("atmospherePressureSeaLevel", body.atmospherePressureSeaLevel);
+                node.AddValue("atmDensityASL", body.atmDensityASL);
+                node.AddValue("atmosphereGasMassLapseRate", body.atmosphereGasMassLapseRate);
                 node.AddValue("atmosphereMolarMass", body.atmosphereMolarMass);
                 node.AddValue("atmosphereAdiabaticIndex", body.atmosphereAdiabaticIndex);
+                node.AddValue("radiusAtmoFactor", body.radiusAtmoFactor);
+                node.AddValue("atmosphereUsePressureCurve", body.atmosphereUsePressureCurve);
+                node.AddValue("atmospherePressureCurveIsNormalized", body.atmospherePressureCurveIsNormalized);
+                if (body.atmospherePressureCurve != null)
+                {
+                    ConfigNode apc = node.AddNode("atmospherePressureCurve");
+                    body.atmospherePressureCurve.Save(apc);
+                }
+                node.AddValue("atmosphereUseTemperatureCurve", body.atmosphereUseTemperatureCurve);
+                node.AddValue("atmosphereTemperatureCurveIsNormalized", body.atmosphereTemperatureCurveIsNormalized);
+                if (body.atmosphereTemperatureCurve != null)
+                {
+                    ConfigNode tpc = node.AddNode("atmosphereTemperatureCurve");
+                    body.atmosphereTemperatureCurve.Save(tpc);
+                }
+                if (body.atmosphereTemperatureSunMultCurve != null)
+                {
+                    ConfigNode atsmc = node.AddNode("atmosphereTemperatureSunMultCurve");
+                    body.atmosphereTemperatureSunMultCurve.Save(atsmc);
+                }
                 node.AddValue("rotates", body.rotates);
                 node.AddValue("rotationPeriod", body.rotationPeriod);
                 node.AddValue("initialRotation", body.initialRotation);
@@ -162,9 +251,38 @@ namespace HyperEdit.Model
                 node.TryGetValue("atmosphereContainsOxygen", ref body.atmosphereContainsOxygen, bool.TryParse);
                 node.TryGetValue("atmosphereDepth", ref body.atmosphereDepth, double.TryParse);
                 node.TryGetValue("atmosphereTemperatureSeaLevel", ref body.atmosphereTemperatureSeaLevel, double.TryParse);
+                node.TryGetValue("atmosphereTemperatureLapseRate", ref body.atmosphereTemperatureLapseRate, double.TryParse);
                 node.TryGetValue("atmospherePressureSeaLevel", ref body.atmospherePressureSeaLevel, double.TryParse);
+                node.TryGetValue("atmDensityASL", ref body.atmDensityASL, double.TryParse);
+                node.TryGetValue("atmosphereGasMassLapseRate", ref body.atmosphereGasMassLapseRate, double.TryParse);
                 node.TryGetValue("atmosphereMolarMass", ref body.atmosphereMolarMass, double.TryParse);
                 node.TryGetValue("atmosphereAdiabaticIndex", ref body.atmosphereAdiabaticIndex, double.TryParse);
+                node.TryGetValue("radiusAtmoFactor", ref body.radiusAtmoFactor, double.TryParse);
+                node.TryGetValue("atmosphereUsePressureCurve", ref body.atmosphereUsePressureCurve, bool.TryParse);
+                node.TryGetValue("atmospherePressureCurveIsNormalized", ref body.atmospherePressureCurveIsNormalized, bool.TryParse);
+                ConfigNode apc = new ConfigNode();
+                if (node.TryGetNode("atmospherePressureCurve", ref apc))
+                {
+                    FloatCurve floatCurve = new FloatCurve();
+                    floatCurve.Load(apc);
+                    body.atmospherePressureCurve = floatCurve;
+                }
+                node.TryGetValue("atmosphereUseTemperatureCurve", ref body.atmosphereUseTemperatureCurve, bool.TryParse);
+                node.TryGetValue("atmosphereTemperatureCurveIsNormalized", ref body.atmosphereTemperatureCurveIsNormalized, bool.TryParse);
+                ConfigNode tpc = new ConfigNode();
+                if (node.TryGetNode("atmosphereTemperatureCurve", ref tpc))
+                {
+                    FloatCurve floatCurve = new FloatCurve();
+                    floatCurve.Load(tpc);
+                    body.atmosphereTemperatureCurve = floatCurve;
+                }
+                ConfigNode atsmc = new ConfigNode();
+                if (node.TryGetNode("atmosphereTemperatureSunMultCurve", ref atsmc))
+                {
+                    FloatCurve floatCurve = new FloatCurve();
+                    floatCurve.Load(atsmc);
+                    body.atmosphereTemperatureSunMultCurve = floatCurve;
+                }
                 node.TryGetValue("rotates", ref body.rotates, bool.TryParse);
                 node.TryGetValue("rotationPeriod", ref body.rotationPeriod, double.TryParse);
                 node.TryGetValue("initialRotation", ref body.initialRotation, double.TryParse);

--- a/Source/Model/SiSuffix.cs
+++ b/Source/Model/SiSuffix.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using UnityEngine;
+
 namespace HyperEdit.Model
 {
     public static class SiSuffix
@@ -55,6 +57,28 @@ namespace HyperEdit.Model
                 return false;
             value *= multiplier;
             return true;
+        }
+
+        public static bool TryParse(string s, out FloatCurve value)
+        {
+            value = new FloatCurve();
+            try {
+                JsonUtility.FromJsonOverwrite(s, value);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
+        public static bool TryParse(string s, out String value) {
+            value = s;
+            return true;
+        }
+
+        public static bool TryParseFloatCurve(string s, out string value) {
+            value = s;
+            FloatCurve floatCurve;
+            return TryParse(s, out floatCurve);
         }
 
         /*

--- a/Source/View/PlanetEditorView.cs
+++ b/Source/View/PlanetEditorView.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+using UnityEngine;
+
 namespace HyperEdit.View
 {
     public static class PlanetEditorView
@@ -20,9 +22,20 @@ namespace HyperEdit.View
             var atmosphereContainsOxygen = new ToggleView("Atmosphere contains oxygen", "Whether jet engines work or not", false);
             var atmosphereDepth = new TextBoxView<double>("Atmosphere depth", "Theoretically atmosphere height. In reality, doesn't work too well.", 1, Model.SiSuffix.TryParse);
             var atmosphereTemperatureSeaLevel = new TextBoxView<double>("atmosphereTemperatureSeaLevel", "New 1.0 field. Unknown what this does.", 1, Model.SiSuffix.TryParse);
+            var atmosphereTemperatureLapseRate = new TextBoxView<double>("atmosphereTemperatureLapseRate", "Unknown", 1, Model.SiSuffix.TryParse);
             var atmospherePressureSeaLevel = new TextBoxView<double>("atmospherePressureSeaLevel", "New 1.0 field. Unknown what this does.", 1, Model.SiSuffix.TryParse);
+            var atmDensityASL = new TextBoxView<double>("atmDensityASL", "New 1.4-ish field. Unknown what this does.", 1, Model.SiSuffix.TryParse);
+            var atmosphereGasMassLapseRate = new TextBoxView<double>("atmosphereGasMassLapseRate", "New 1.4-ish field. Unknown what this does.", 1, Model.SiSuffix.TryParse);
             var atmosphereMolarMass = new TextBoxView<double>("atmosphereMolarMass", "New 1.0 field. Unknown what this does.", 1, Model.SiSuffix.TryParse);
             var atmosphereAdiabaticIndex = new TextBoxView<double>("atmosphereAdiabaticIndex", "New 1.0 field. Unknown what this does.", 1, Model.SiSuffix.TryParse);
+            var radiusAtmoFactor = new TextBoxView<double>("radiusAtmoFactor", "Unknown", 1, Model.SiSuffix.TryParse);
+            var atmosphereUsePressureCurve = new ToggleView("Use atmospheric pressure curve", "Unknown", false);
+            var atmospherePressureCurveIsNormalized = new ToggleView("Atmospheric pressure curve is normalized", "Unknown", false);
+            var atmospherePressureCurve = new TextAreaView<String>("atmospherePressureCurve", "Atmosphere pressure curve", "", Model.SiSuffix.TryParseFloatCurve);
+            var atmosphereUseTemperatureCurve = new ToggleView("Use atmospheric temperature curve", "Unknown", false);
+            var atmosphereTemperatureCurveIsNormalized = new ToggleView("Atmospheric temperature curve is normalized", "Unknown", false);
+            var atmosphereTemperatureCurve = new TextAreaView<String>("atmosphereTemperatureCurve", "Atmosphere temperature curve", "", Model.SiSuffix.TryParseFloatCurve);
+            var atmosphereTemperatureSunMultCurve = new TextAreaView<String>("atmosphereTemperatureSunMultCurve", "Atmosphere temperature sun mult curve", "", Model.SiSuffix.TryParseFloatCurve);
             var rotates = new ToggleView("Rotates", "If the planet rotates.", false);
             var rotationPeriod = new TextBoxView<double>("Rotation period", "Rotation period of the planet, in seconds.", 1, Model.SiSuffix.TryParse);
             var initialRotation = new TextBoxView<double>("Initial rotation", "Absolute rotation in degrees of the planet at time=0", 1, Model.SiSuffix.TryParse);
@@ -37,9 +50,20 @@ namespace HyperEdit.View
                 atmosphereContainsOxygen.Value = body.atmosphereContainsOxygen;
                 atmosphereDepth.Object = body.atmosphereDepth;
                 atmosphereTemperatureSeaLevel.Object = body.atmosphereTemperatureSeaLevel;
+                atmosphereTemperatureLapseRate.Object = body.atmosphereTemperatureLapseRate;
                 atmospherePressureSeaLevel.Object = body.atmospherePressureSeaLevel;
+                atmDensityASL.Object = body.atmDensityASL;
+                atmosphereGasMassLapseRate.Object = body.atmosphereGasMassLapseRate;
                 atmosphereMolarMass.Object = body.atmosphereMolarMass;
                 atmosphereAdiabaticIndex.Object = body.atmosphereAdiabaticIndex;
+                radiusAtmoFactor.Object = body.radiusAtmoFactor;
+                atmosphereUsePressureCurve.Value = body.atmosphereUsePressureCurve;
+                atmospherePressureCurveIsNormalized.Value = body.atmospherePressureCurveIsNormalized;
+                atmospherePressureCurve.Object = JsonUtility.ToJson(body.atmospherePressureCurve, true);
+                atmosphereUseTemperatureCurve.Value = body.atmosphereUseTemperatureCurve;
+                atmosphereTemperatureCurveIsNormalized.Value = body.atmosphereTemperatureCurveIsNormalized;
+                atmosphereTemperatureCurve.Object = JsonUtility.ToJson(body.atmospherePressureCurve, true);
+                atmosphereTemperatureSunMultCurve.Object = JsonUtility.ToJson(body.atmosphereTemperatureSunMultCurve, true);
                 rotates.Value = body.rotates;
                 rotationPeriod.Object = body.rotationPeriod;
                 initialRotation.Object = body.initialRotation;
@@ -53,9 +77,16 @@ namespace HyperEdit.View
                             geeAsl.Valid &&
                             atmosphereDepth.Valid &&
                             atmosphereTemperatureSeaLevel.Valid &&
+                            atmosphereTemperatureLapseRate.Valid &&
                             atmospherePressureSeaLevel.Valid &&
+                            atmDensityASL.Valid &&
+                            atmosphereGasMassLapseRate.Valid &&
                             atmosphereMolarMass.Valid &&
                             atmosphereAdiabaticIndex.Valid &&
+                            radiusAtmoFactor.Valid &&
+                            atmospherePressureCurve.Valid &&
+                            atmosphereTemperatureCurve.Valid &&
+                            atmosphereTemperatureSunMultCurve.Valid &&
                             rotationPeriod.Valid &&
                             initialRotation.Valid,
                             new ButtonView("Apply", "Applies the changes to the body", () =>
@@ -67,9 +98,20 @@ namespace HyperEdit.View
                             atmosphereContainsOxygen.Value,
                             atmosphereDepth.Object,
                             atmosphereTemperatureSeaLevel.Object,
+                            atmosphereTemperatureLapseRate.Object,
                             atmospherePressureSeaLevel.Object,
+                            atmDensityASL.Object,
+                            atmosphereGasMassLapseRate.Object,
                             atmosphereMolarMass.Object,
                             atmosphereAdiabaticIndex.Object,
+                            radiusAtmoFactor.Object,
+                            atmosphereUsePressureCurve.Value,
+                            atmospherePressureCurveIsNormalized.Value,
+                            JsonUtility.FromJson<FloatCurve>(atmospherePressureCurve.Object),
+                            atmosphereUseTemperatureCurve.Value,
+                            atmosphereTemperatureCurveIsNormalized.Value,
+                            JsonUtility.FromJson<FloatCurve>(atmosphereTemperatureCurve.Object),
+                            JsonUtility.FromJson<FloatCurve>(atmosphereTemperatureSunMultCurve.Object),
                             rotates.Value,
                             rotationPeriod.Object,
                             initialRotation.Object,
@@ -79,21 +121,36 @@ namespace HyperEdit.View
 
             var editFields = new ConditionalView(() => body != null, new VerticalView(new IView[]
                     {
-                        geeAsl,
-                        ocean,
-                        atmosphere,
-                        atmosphereContainsOxygen,
-                        atmosphereDepth,
-                        atmosphereTemperatureSeaLevel,
-                        atmospherePressureSeaLevel,
-                        atmosphereMolarMass,
-                        atmosphereAdiabaticIndex,
-                        rotates,
-                        rotationPeriod,
-                        initialRotation,
-                        tidallyLocked,
-                        apply,
-                    }));
+                        new ScrollView(new VerticalView(new IView[]
+                        {
+                            geeAsl,
+                            ocean,
+                            atmosphere,
+                            atmosphereContainsOxygen,
+                            atmosphereDepth,
+                            atmosphereTemperatureSeaLevel,
+                            atmosphereTemperatureLapseRate,
+                            atmospherePressureSeaLevel,
+                            atmDensityASL,
+                            atmosphereGasMassLapseRate,
+                            atmosphereMolarMass,
+                            atmosphereAdiabaticIndex,
+                            radiusAtmoFactor,
+                            atmosphereUsePressureCurve,
+                            atmospherePressureCurveIsNormalized,
+                            atmospherePressureCurve,
+                            atmosphereUseTemperatureCurve,
+                            atmosphereTemperatureCurveIsNormalized,
+                            atmosphereTemperatureCurve,
+                            atmosphereTemperatureSunMultCurve,
+                            rotates,
+                            rotationPeriod,
+                            initialRotation,
+                            tidallyLocked
+                }), GUILayout.MinHeight(600), GUILayout.MaxHeight(Screen.height - 200)),
+                        apply
+                    }
+            ));
 
             var resetToDefault = new ConditionalView(() => body != null,
                                      new ButtonView("Reset to defaults", "Reset the selected planet to defaults",


### PR DESCRIPTION
Fixes #52.

The properties are [FloatCurves](https://kerbalspaceprogram.com/api/class_float_curve.html), which contain arrays of [Keyframes](https://docs.unity3d.com/ScriptReference/Keyframe.html), so I figured the best way to represent that was with a text area instead of a simple text box. Unfortunately they aren't really explained in the [official API documentation](https://kerbalspaceprogram.com/api/class_celestial_body.html)  but I can confirm from local testing that they take effect when you copy from Eve to Kerbin.