### PR TITLE
Update .version file to KSP 1.12.99

### DIFF
--- a/HyperEdit.version
+++ b/HyperEdit.version
@@ -20,7 +20,7 @@
   },
   "KSP_VERSION_MAX": {
     "MAJOR": 1,
-    "MINOR": 10,
+    "MINOR": 12,
     "PATCH": 99
   }
 }


### PR DESCRIPTION
I haven't seen any compatibility issues reported, so this should be updated to allow for it to be installed in CKAN without having to manually override it. Should updated in the .zip too, but I don't have access to that of course.